### PR TITLE
Relax dependency on integer-gmp to support GHC 7.4

### DIFF
--- a/text-format.cabal
+++ b/text-format.cabal
@@ -57,7 +57,7 @@ library
   cpp-options: -DINTEGER_GMP
 
   if impl(ghc >= 6.11)
-    build-depends: integer-gmp >= 0.2 && < 0.4
+    build-depends: integer-gmp >= 0.2 && < 0.5
 
   if impl(ghc >= 6.9) && impl(ghc < 6.11)
     build-depends: integer >= 0.1 && < 0.2


### PR DESCRIPTION
GHC 7.4 ships with integer-gmp-0.4.0.0
